### PR TITLE
Automatically create spatialite db on migrate

### DIFF
--- a/TheAuditTrail/settings.py
+++ b/TheAuditTrail/settings.py
@@ -64,7 +64,6 @@ WSGI_APPLICATION = 'TheAuditTrail.wsgi.application'
 
 DATABASES = {
     'default': {
-#        'ENGINE': 'django.db.backends.sqlite3',
         'ENGINE': 'django.contrib.gis.db.backends.spatialite',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }

--- a/manage.py
+++ b/manage.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 import os
 import sys
+import subprocess
+
+
+def create_spatialite_db():
+    if not os.path.isfile("db.sqlite3"):
+        subprocess.call(['spatialite', 'db.sqlite3', 'SELECT InitSpatialMetaData();'])
+
 
 if __name__ == "__main__":
+    create_spatialite_db()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TheAuditTrail.settings")
 
     from django.core.management import execute_from_command_line


### PR DESCRIPTION
Checks for DB file, if it doesn't exist then it creates it.
